### PR TITLE
Switch to using ProductBuildVersion for 15.3+ Compatibility Checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,21 +31,21 @@ Just like Xcode's original plugin system, this loader checks plugin bundles for 
 
 For Xcode 14.0 - 15.2, plugins can add [`DVTPlugInCompatibilityUUIDs`](https://gist.github.com/minsko/9124ee24b9422fb8ea6b8d00815783ba) to their `Info.plist` files to specify which versions of Xcode they're compatible with.
 
-For Xcode 15.3+, plugins should instead specify `DTXcodeBuildCompatibleVersions` in their `Info.plist` file, based on Xcode's build number (like `15E5194e`). The lowercase letter suffix is optional and should generally be dropped, unless compatibility with specific builds is needed.
+For Xcode 15.3+, plugins should instead specify `CompatibleProductBuildVersions` in their `Info.plist` file, based on Xcode's build version (like `15E204a`).
 
 These two compatibility values can exist side-by-side:
 
 ```xml
-<key>DTXcodeBuildCompatibleVersions</key>
+<key>CompatibleProductBuildVersions</key>
 <array>
-  <string>15E5178</string>
-  <string>15E5188</string>
+  <string>15E204a</string>  <!-- 15.3 -->
+  <string>15E5178i</string> <!-- 15.3b1 -->
 </array>
 <key>DVTPlugInCompatibilityUUIDs</key>
 <array>
-  <string>EFD92DF8-D0A2-4C92-B6E3-9B3CD7E8DC19</string>
-  <string>8BAA96B4-5225-471B-B124-D32A349B8106</string>
-  <string>7A3A18B7-4C08-46F0-A96A-AB686D315DF0</string>
+  <string>EFD92DF8-D0A2-4C92-B6E3-9B3CD7E8DC19</string> <!-- 13.4 -->
+  <string>7A3A18B7-4C08-46F0-A96A-AB686D315DF0</string> <!-- 13.2 -->
+  <string>8BAA96B4-5225-471B-B124-D32A349B8106</string> <!-- 13.0 -->
 </array>
 ```
 

--- a/XcodePluginLoader.xcodeproj/project.pbxproj
+++ b/XcodePluginLoader.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		020463A72B7535A000BF01DB /* ClassLoadObserver.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ClassLoadObserver.h; sourceTree = "<group>"; };
 		020463A82B7535A000BF01DB /* ClassLoadObserver.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ClassLoadObserver.m; sourceTree = "<group>"; };
 		020463AB2B753EF800BF01DB /* DVTPlugInManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DVTPlugInManager.h; sourceTree = "<group>"; };
+		02AE2E362B9F46F4006AF5FD /* NSProcessInfo+PBXTSPlatformAdditions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSProcessInfo+PBXTSPlatformAdditions.h"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -68,6 +69,7 @@
 			isa = PBXGroup;
 			children = (
 				020463AB2B753EF800BF01DB /* DVTPlugInManager.h */,
+				02AE2E362B9F46F4006AF5FD /* NSProcessInfo+PBXTSPlatformAdditions.h */,
 				020463A62B75355700BF01DB /* XcodePlugin.h */,
 			);
 			path = XcodeHeaders;

--- a/XcodePluginLoader/XcodeHeaders/NSProcessInfo+PBXTSPlatformAdditions.h
+++ b/XcodePluginLoader/XcodeHeaders/NSProcessInfo+PBXTSPlatformAdditions.h
@@ -1,0 +1,10 @@
+#import <Foundation/Foundation.h>
+
+/**
+ Based on `NSProcessInfo(PBXTSPlatformAdditions)` category in Xcode 15.2
+ */
+@interface NSProcessInfo (PBXTSPlatformAdditions)
+
+- (NSString *)xcodeProductBuildVersion;
+
+@end


### PR DESCRIPTION
Fixes #1 - `DTXcodeBuild` was _not_ the right value to be using for compatibility checks!

Tested locally using [XcodeVimMap](https://github.com/bryce-co/XcodeVimMap/commit/6fbf21726a67774cfdf37e65d8de7ab9663e9210).