### PR TITLE
Add Xcode 16.0b1 Compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # XcodePluginLoader
 
-Add plugin support back to Xcode 14+!
+Add plugin support back to Xcode 14+! Tested on Xcode 14.0 - Xcode 16.0b1.
 
 `XcodePluginLoader` is a lightweight, drop-in replacement for Xcode's built-in plugin system, which was removed in [Xcode 14.0b3](https://github.com/XVimProject/XVim2/issues/398).
 
@@ -18,7 +18,7 @@ A much deeper dive is available on [bryce.co](https://bryce.co/xcode-plugin-load
 
 1) [Re-Sign Xcode](https://github.com/XVimProject/XVim2/blob/master/SIGNING_Xcode.md) (the same process you already had to in order to use plugins from Xcode 8 - Xcode 13)
 
-(Note: this limits some functionality within Xcode. Consider keeping a signed copy of Xcode around as well. You can alternatively disable SIP at the expense of security)
+(Note: this limits some functionality within Xcode, including AI-based code completion, Swift previews, and account management. Consider keeping a signed copy of Xcode around as well. You can alternatively disable SIP at the expense of security)
 
 2. Build or download the latest release of `XcodePluginLoader`
 3. Copy `XcodePluginLoader.dylib` into `Xcode.app/Contents`

--- a/XcodePluginLoader/XcodePluginLoader.m
+++ b/XcodePluginLoader/XcodePluginLoader.m
@@ -28,7 +28,7 @@ NSString * __nonnull  const pluginDirectory = @"~/Library/Application Support/De
     // Wait for classes to load before performing actual plugin loading
     __weak typeof(self) weakSelf = self;
     self.classLoadObserver = [ClassLoadObserver observerForClasses:@[
-        @"PBXTSTask", // Needed for Xcode 15.3+ compatibility checks (as a proxy for NSProcessInfo(PBXTSPlatformAdditions) being loaded)
+        @"TSFileManager", // Needed for Xcode 15.3+ compatibility checks (as a proxy for NSProcessInfo(PBXTSPlatformAdditions) being loaded)
         @"DVTPlugInManager" // Needed for pre Xcode 15.3 compatibility checks
     ] completion:^{
         [weakSelf loadPlugins];


### PR DESCRIPTION
Updates our class load listener to wait for `TSFileManager` instead of `PBXTSTask` (which no longer exists).

Long-term, we may want the ability to listen for a specific method directly (rather than relying on classes that happen to exist in the same binary as the category method we're interested in), but this is a quick fix for now.